### PR TITLE
Custom fields on devices api response

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ be configured to manage the data import process from the script.
             'api_is_source_of_truth': True,         # Data received from API is considered the soruce of truth and will overwrite non matching data
             'use_eos_for_missing': True,            # If a date is not returned, use end_of_support as the date to use, otherwise null values retained
             'hw_lcm_migration_calc_month': 6,       # Month used to calc replacement and budget years. Default is 6
+            'lcm_device_cf_whitelist': [
+                'dot1x_enforcement',
+                'dot1x_device_last_measured',
+                'backup_system',
+                'backup_notes',
+                # add whatever you want exposed by default
+            ] # Include custom fields that should be exposed in the devices api view.
         },
     ],
 ```

--- a/netbox_lcm/api/_serializers/device.py
+++ b/netbox_lcm/api/_serializers/device.py
@@ -1,4 +1,5 @@
 from django.contrib.contenttypes.models import ContentType
+from django.conf import settings
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 from tenancy.api.serializers_.tenants import TenantSerializer
@@ -64,6 +65,7 @@ class DeviceLifecycleSerializer(NetBoxModelSerializer):
         nested=True, source='prefetched_contracts', many=True, read_only=True
     )
     hw_lifecycle = serializers.SerializerMethodField()
+    custom_fields = serializers.SerializerMethodField(read_only=True)
     
 
     def get_hw_lifecycle(self, obj):
@@ -92,9 +94,29 @@ class DeviceLifecycleSerializer(NetBoxModelSerializer):
             "label": label
         }
 
+    def get_custom_fields(self, obj: Device):
+        # Pull allowed CF names from ?cf=cf1,cf2 or fall back to settings
+        request = self.context.get('request')
+        if request and request.query_params.get('cf'):
+            names = [
+                n.strip() for n in request.query_params.get('cf', '').split(',')
+                if n.strip()
+            ]
+        else:
+            names = getattr(settings, 'PLUGINS_CONFIG', {}).get(
+                'netbox_lcm', {}
+            ).get('lcm_device_cf_whitelist', [])
+
+        # NetBox v4 keeps raw dict on `custom_field_data`
+        data = getattr(obj, 'custom_field_data', {}) or {}
+
+        # Return only keys requested AND present; missing keys get ignored
+        return {k: data.get(k) for k in names if k in data}
+
     class Meta:
         model = Device
         fields = [
             'id', 'name', 'status', 'site', 'device_type', 'tenant',
-            'hw_lifecycle', 'support_coverage_status', 'support_contract_count', 'support_contracts'
+            'hw_lifecycle', 'support_coverage_status', 'support_contract_count', 'support_contracts',
+            'custom_fields'
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ description = "NetBox Lifecycle Management Plugin"
 readme = "README.md"
 requires-python = ">=3.10"
 keywords = ["netbox-plugin", ]
-version = "1.1.7"
+version = "1.1.8"
 license = {file = "LICENSE"}
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
This adds custom fields to the api response from the devices view.  CF's to include can be included in the lcm settings in the plugin configuration.  Primarily used to allow things like dot1x compliance and backup details to be included where we're still using CF's to track this kind of data against device.